### PR TITLE
Remove osm.query() logic.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/). This
+project adheres to [Semantic Versioning](http://semver.org/).
+
+## 3.0.0 - 2017-04-30
+*Breaking API change and major semver version bump!*
+### Changed
+- The main `getGeoJSON` API now returns a Transform stream that accepts
+  ndjson-formatted OSM documents and writes GeoJSON on the other side. This
+  means API consumers must perform an `osm.query()` call on an `osm-p2p-db`
+  instance themselves and feed it into `getGeoJSON()` rather than relying on
+  `osm-p2p-geojson` to do OSM database querying for them.
+### Added
+- Add optional map function - applied to each feature
+
+## 2.0.0 - 2016-09-05
+*Breaking API change and major semver version bump!*
+### Changed
+- Accept the query bounding box as `opts.bbox` rather than mandatory parameter
+  `q`. `opts.bbox` defaults to `Infinity`.
+- The GeoJSON bounding box format of `[minLat, maxLat, minLon, maxLon]` is used.
+
+## 1.1.0 - 2016-09-03
+### Added
+- Initial implementation.
+

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ Get GeoJSON from the database. GeoJSON is returned as a readable stream, or, if 
 - `options.objectMode` - when `true` will return a stream of GeoJSON feature objects instead of stringified JSON. Default `false`. You can also use `getGeoJSON.obj()`
 - `options.map` - a function that maps a `Feature` to another `Feature`. Defaults to the no-op `function mapFn (feature) { return feature }`
 
+**N.B.**: If `options.objectMode` is enabled and no `callback` is provided, the
+resultant object stream will emit GeoJSON `Feature` objects. This is not valid
+GeoJSON as-is: the recipient of the stream will need to either wrap these
+`Feature`s into a `FeatureCollection` or otherwise further transform them.
+
 ## Contribute
 
 PRs accepted.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # osm-p2p-geojson
 
-> Export GeoJSON from osm-p2p-db
+> Transform OSM documents in an osm-p2p-db to GeoJSON
 
 ## Table of Contents
 
@@ -19,13 +19,25 @@ npm install osm-p2p-geojson
 ## Usage
 
 ```js
+// streaming:
 var getGeoJSON = require('osm-p2p-geojson')
 var stream = getGeoJSON(osm)
-stream.pipe(process.stdout)
-// pipes GeoJSON to stdout...
-getGeoJSON(osm, function (err, geojson) {
-  console.log(geojson)
-  // outputs geojson object
+
+var q = osm.query({
+  bbox: [-Infinity, -Infinity, Infinity, Infinity]
+})
+
+// outputs geojson object
+q.pipe(stream).pipe(process.stdout)
+
+// or as callbacks:
+osm.query({
+  bbox: [-Infinity, -Infinity, Infinity, Infinity]
+}, function (err, docs) {
+  getGeoJSON(osm, { docs: docs }, function (err, geojson) {
+    console.log(geojson)
+    // outputs geojson object
+  })
 })
 ```
 
@@ -35,12 +47,13 @@ getGeoJSON(osm, function (err, geojson) {
 var getGeoJSON = require('osm-p2p-geojson')
 ```
 
-### var rstream = getGeoJSON(osm[, options][, callback])
+### var stream = getGeoJSON(osm[, options][, callback])
 
 Get GeoJSON from the database. GeoJSON is returned as a readable stream, or, if passed, `callback(err, geoJson)`.
 
 - `osm` - a [`osm-p2p-db`](https://github.com/digidem/osm-p2p-db)
-- `options.bbox` - bounding box to export, defaults to `[-Infinity, -Infinity, Infinity, Infinity]`
+- `docs` - a list of OSM documents. If not provided here, they must be written
+  to the returned `stream`.
 - `options.metadata` - Array of metadata properties to include as GeoJSON properties. Defaults to `['id', 'version', 'timestamp']`
 - `options.objectMode` - when `true` will return a stream of GeoJSON feature objects instead of stringified JSON. Default `false`. You can also use `getGeoJSON.obj()`
 - `options.map` - a function that maps a `Feature` to another `Feature`. Defaults to the no-op `function mapFn (feature) { return feature }`

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ var getGeoJSON = require('osm-p2p-geojson')
 
 ### var stream = getGeoJSON(osm[, options][, callback])
 
-Get GeoJSON from the database. GeoJSON is returned as a readable stream, or, if passed, `callback(err, geoJson)`.
+Creates a TransformStream that will take as input a stream of osm-p2p documents
+and outputs a stream of GeoJSON. If you prefer a callback rather than a stream
+for reading output, you can pass `callback(err, geojson)`.
 
 - `osm` - a [`osm-p2p-db`](https://github.com/digidem/osm-p2p-db)
 - `docs` - a list of OSM documents. If not provided here, they must be written

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "author": "Gregor MacLennan",
   "license": "MIT",
   "devDependencies": {
-    "concat-stream": "^1.5.2",
     "fd-chunk-store": "^2.0.0",
     "hyperlog": "^4.10.0",
     "memdb": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "hyperlog": "^4.10.0",
     "memdb": "^1.3.1",
     "memory-chunk-store": "^1.2.0",
+    "mkdirp": "^0.5.1",
     "osm-p2p-db": "^3.9.3",
     "rimraf": "^2.6.1",
     "standard": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "JSONStream": "^1.1.4",
     "collect-stream": "^1.1.1",
+    "from2": "^2.3.0",
     "geojson-rewind": "^0.2.0",
     "once": "^1.3.3",
     "osm-polygon-features": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "memdb": "^1.3.1",
     "memory-chunk-store": "^1.2.0",
     "osm-p2p-db": "^3.9.3",
+    "rimraf": "^2.6.1",
     "standard": "^8.0.0",
     "tape": "^4.6.0"
   },


### PR DESCRIPTION
This breaks out the internal osm.query() call that formerly happened in osm-p2p-geojson, requiring that the module consumer provide these documents via their own call to osm.query() or otherwise.

This enables intermediary transform streams on the OSM data before it is exported, such as removing forks from the dataset.

Major breaking change.