### PR TITLE
return stream from .obj()

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports.obj = function (osm, opts, cb) {
     cb = opts
     opts = null
   }
-  getGeoJSON(osm, xtend({objectMode: true, highWaterMark: 16}, opts), cb)
+  return getGeoJSON(osm, xtend({objectMode: true, highWaterMark: 16}, opts), cb)
 }
 
 function getGeoJSON (osm, opts, cb) {


### PR DESCRIPTION
a little fix to make the `.obj()` version of this streamable.