### PR TITLE
Replace geojsonhint with geojson-validation package

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,8 +71,8 @@ function getGeoJSON (osm, opts, cb) {
 
       geometry = rewindFixed(geometry)
 
-      var errors = GJV.valid(geometry)
-      if (errors.length > 0) {
+      // Skip invalid geometry
+      if (!GJV.valid(geometry)) {
         return next()
       }
 
@@ -184,14 +184,9 @@ function assembleGeometries (geoms) {
   if (numTypes === 1 && dissolvableTypes.indexOf(type) !== -1) {
     geoms = geoms.map(rewindFixed)
 
-    var errors = geoms.reduce(function (accum, geom) {
-      var errs = GJV.valid(geom)
-      if (errs.length > 0) return accum.concat(errs)
-      else return accum
-    }, [])
-    if (errors.length > 0) {
-      // skip
-      return {}
+    // Skip if any of the geometries are invalid GeoJson
+    for (var i = 0; i < geoms.length; i++) {
+      if (!GJV.valid(geoms[i])) return {}
     }
 
     return dissolve(types[type])

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var collect = require('collect-stream')
 var from = require('from2')
 var amap = require('map-limit')
 var dissolve = require('geojson-dissolve')
-var geoJsonHints = require('@mapbox/geojsonhint').hint
+var GJV = require('geojson-validation')
 
 var Importer = require('./lib/importer.js')
 var FCStream = require('./lib/geojson_fc_stream')
@@ -71,7 +71,7 @@ function getGeoJSON (osm, opts, cb) {
 
       geometry = rewindFixed(geometry)
 
-      var errors = geoJsonHints(geometry)
+      var errors = GJV.valid(geometry)
       if (errors.length > 0) {
         return next()
       }
@@ -185,7 +185,7 @@ function assembleGeometries (geoms) {
     geoms = geoms.map(rewindFixed)
 
     var errors = geoms.reduce(function (accum, geom) {
-      var errs = geoJsonHints(geom)
+      var errs = GJV.valid(geom)
       if (errs.length > 0) return accum.concat(errs)
       else return accum
     }, [])
@@ -287,4 +287,3 @@ function rewindFixed (gj) {
     return rewind(gj)
   }
 }
-

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "traverse": "^0.6.6"
   },
   "dependencies": {
-    "@mapbox/geojsonhint": "^2.1.0",
     "JSONStream": "^1.1.4",
     "clone": "^2.1.0",
     "collect-stream": "^1.1.1",
@@ -38,6 +37,7 @@
     "geojson-dissolve": "^3.1.0",
     "geojson-polygons-equal": "0.0.1",
     "geojson-rewind": "^0.2.0",
+    "geojson-validation": "^0.2.1",
     "inherits": "^2.0.3",
     "map-limit": "0.0.1",
     "once": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "devDependencies": {
     "clone": "^2.1.1",
     "concat-stream": "^1.6.0",
-    "from2": "^2.3.0",
     "kappa-core": "^4.0.0",
     "kappa-osm": "^3.0.0",
     "level": "^4.0.0",


### PR DESCRIPTION
Quick patch to replace unmaintained '@mapbox/geojsonhint' package [bug #15](https://github.com/digidem/osm-p2p-geojson/issues/15). Resolve the TravisCI build failures [bug #236](https://github.com/digidem/mapeo-desktop/issues/236)

Please kindly review and advice @gmaclennan @noffle . Thanks! 